### PR TITLE
Overlap between trees

### DIFF
--- a/aabbtree.py
+++ b/aabbtree.py
@@ -535,25 +535,72 @@ class AABBTree(object):
         Returns:
             list: AABB objects in AABBTree that overlap with the input.
         """
+        pairs = self._overlap_pairs(aabb, method)
+        if len(pairs) == 0:
+            return []
+        boxes, _ = zip(*pairs)
+        return list(boxes)
+
+    def overlap_values(self, aabb, method='DFS'):
+        """Get values of overlapping AABBs
+
+        This function gets the value field of each overlapping AABB.
+
+        *New  in version 2.6.0*
+
+        This method also supports overlap checks with another instance of the
+        AABBTree class.
+
+        Args:
+            aabb (AABB or AABBTree): The AABB or AABBTree to check.
+            method (str): {'DFS'|'BFS'} Method for traversing the tree.
+                Setting 'DFS' performs a depth-first search and 'BFS' performs
+                a breadth-first search. Defaults to 'DFS'.
+
+        Returns:
+            list: Value fields of each node that overlaps.
+        """
+        pairs = self._overlap_pairs(aabb, method)
+        if len(pairs) == 0:
+            return []
+        _, values = zip(*pairs)
+        return list(values)
+
+    def _overlap_pairs(self, aabb, method='DFS'):
+        """Get overlapping AABBs and values in (AABB, value) pairs
+
+        *New  in version 2.6.0*
+
+        This function gets each overlapping AABB and its value.
+
+        Args:
+            aabb (AABB or AABBTree): The AABB or AABBTree to check.
+            method (str): {'DFS'|'BFS'} Method for traversing the tree.
+                Setting 'DFS' performs a depth-first search and 'BFS' performs
+                a breadth-first search. Defaults to 'DFS'.
+
+        Returns:
+            list: (AABB, value) pairs in AABBTree that overlap with the input.
+        """
         if isinstance(aabb, AABB):
             tree = AABBTree(aabb=aabb)
         else:
             tree = aabb
 
-        aabbs = []
+        pairs = []
 
         if method == 'DFS':
             if self.is_leaf and self.does_overlap(tree, method):
-                aabbs.append(self.aabb)
+                pairs.append((self.aabb, self.value))
             elif self.is_leaf:
                 pass
             elif tree.is_leaf:
                 for branch in (self.left, self.right):
-                    aabbs.extend(branch.overlap_aabbs(tree, method))
+                    pairs.extend(branch._overlap_pairs(tree, method))
             else:
                 for s_branch in (self.left, self.right):
                     for t_branch in (tree.left, tree.right):
-                        aabbs.extend(s_branch.overlap_aabbs(t_branch, method))
+                        pairs.extend(s_branch._overlap_pairs(t_branch, method))
 
         elif method == 'BFS':
             q = deque()
@@ -562,7 +609,7 @@ class AABBTree(object):
                 s_node, t_node = q.popleft()
                 if s_node.aabb.overlaps(t_node.aabb):
                     if s_node.is_leaf and t_node.is_leaf:
-                        aabbs.append(s_node.aabb)
+                        pairs.append((s_node.aabb, s_node.value))
                     elif s_node.is_leaf:
                         q.append((s_node, t_node.left))
                         q.append((s_node, t_node.right))
@@ -578,52 +625,11 @@ class AABBTree(object):
             e_str = "method should be 'DFS' or 'BFS', not " + str(method)
             raise ValueError(e_str)
 
-        aabbs = [box for i, box in enumerate(aabbs) if box not in aabbs[:i]]
-        return aabbs
-
-    def overlap_values(self, aabb, method='DFS'):
-        """Get values of overlapping AABBs
-
-        This function gets the value field of each overlapping AABB.
-
-        Args:
-            aabb (AABB): The AABB to check.
-            method (str): {'DFS'|'BFS'} Method for traversing the tree.
-                Setting 'DFS' performs a depth-first search and 'BFS' performs
-                a breadth-first search. Defaults to 'DFS'.
-
-        Returns:
-            list: Value fields of each node that overlaps.
-        """
-        values = []
-
-        if method == 'DFS':
-            is_leaf = self.is_leaf
-            if is_leaf and self.does_overlap(aabb):
-                values.append(self.value)
-            elif is_leaf:
-                pass
-            else:
-                if self.left.aabb.overlaps(aabb):
-                    values.extend(self.left.overlap_values(aabb))
-
-                if self.right.aabb.overlaps(aabb):
-                    values.extend(self.right.overlap_values(aabb))
-        elif method == 'BFS':
-            q = deque()
-            q.append(self)
-            while len(q) > 0:
-                node = q.popleft()
-                if node.aabb.overlaps(aabb):
-                    if node.is_leaf:
-                        values.append(node.value)
-                    else:
-                        q.append(node.left)
-                        q.append(node.right)
-        else:
-            e_str = "method should be 'DFS' or 'BFS', not " + str(method)
-            raise ValueError(e_str)
-        return values
+        if len(pairs) < 2:
+            return pairs
+        boxes, _ = zip(*pairs)
+        u_pairs = [p for i, p in enumerate(pairs) if p[0] not in boxes[:i]]
+        return u_pairs
 
 
 def _merge(lims1, lims2):

--- a/aabbtree.py
+++ b/aabbtree.py
@@ -431,8 +431,13 @@ class AABBTree(object):
         This function checks if the limits overlap any leaf nodes in the tree.
         It returns true if there is an overlap.
 
+        *New  in version 2.6.0*
+
+        This method also supports overlap checks with another instance of the
+        AABBTree class.
+
         Args:
-            aabb (AABB): The AABB to check.
+            aabb (AABB or AABBTree): The AABB or AABBTree to check.
             method (str): {'DFS'|'BFS'} Method for traversing the tree.
                 Setting 'DFS' performs a depth-first search and 'BFS' performs
                 a breadth-first search. Defaults to 'DFS'.
@@ -440,30 +445,72 @@ class AABBTree(object):
         Returns:
             bool: True if overlaps with a leaf node of tree.
         """
+        if isinstance(aabb, AABB):
+            tree = AABBTree(aabb=aabb)
+        else:
+            tree = aabb
+
         if method == 'DFS':
+            if self.is_leaf and tree.is_leaf:
+                return self.aabb.overlaps(tree.aabb)
+
             if self.is_leaf:
-                return self.aabb.overlaps(aabb)
+                left_over = tree.left.aabb.overlaps(self.aabb)
+                right_over = tree.right.aabb.overlaps(self.aabb)
 
-            left_aabb_over = self.left.aabb.overlaps(aabb)
-            right_aabb_over = self.right.aabb.overlaps(aabb)
+                if left_over and tree.left.does_overlap(self, method):
+                    return True
+                if right_over and tree.right.does_overlap(self, method):
+                    return True
+                return False
+            if tree.is_leaf:
+                left_over = self.left.aabb.overlaps(tree.aabb)
+                right_over = self.right.aabb.overlaps(tree.aabb)
 
-            if left_aabb_over and self.left.does_overlap(aabb):
+                if left_over and self.left.does_overlap(tree, method):
+                    return True
+                if right_over and self.right.does_overlap(tree, method):
+                    return True
+                return False
+
+            # If both `self` and `tree` are trees
+            if not self.aabb.overlaps(tree.aabb):
+                return False
+
+            left_left = self.left.aabb.overlaps(tree.left.aabb)
+            left_right = self.left.aabb.overlaps(tree.right.aabb)
+            right_left = self.right.aabb.overlaps(tree.left.aabb)
+            right_right = self.right.aabb.overlaps(tree.right.aabb)
+
+            if left_left and self.left.does_overlap(tree.left, method):
                 return True
-            if right_aabb_over and self.right.does_overlap(aabb):
+            if left_right and self.left.does_overlap(tree.right, method):
+                return True
+            if right_left and self.right.does_overlap(tree.left, method):
+                return True
+            if right_right and self.right.does_overlap(tree.right, method):
                 return True
             return False
 
         if method == 'BFS':
             q = deque()
-            q.append(self)
+            q.append((self, tree))
             while len(q) > 0:
-                node = q.popleft()
-                overlaps = node.aabb.overlaps(aabb)
-                if overlaps and node.is_leaf:
+                s_node, t_node = q.popleft()
+                overlaps = s_node.aabb.overlaps(t_node.aabb)
+                if overlaps and s_node.is_leaf and t_node.is_leaf:
                     return True
-                if overlaps:
-                    q.append(node.left)
-                    q.append(node.right)
+                if overlaps and s_node.is_leaf:
+                    q.append((s_node, t_node.left))
+                    q.append((s_node, t_node.right))
+                elif overlaps and t_node.is_leaf:
+                    q.append((s_node.left, t_node))
+                    q.append((s_node.right, t_node))
+                elif overlaps:
+                    q.append((s_node.left, t_node.left))
+                    q.append((s_node.left, t_node.right))
+                    q.append((s_node.right, t_node.left))
+                    q.append((s_node.right, t_node.right))
             return False
 
         e_str = "method should be 'DFS' or 'BFS', not " + str(method)

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ def read(fname):
 
 setup(
     name='aabbtree',
-    version='2.5.0',
+    version='2.6.0',
     license='MIT',
     description='Pure Python implementation of d-dimensional AABB tree.',
     long_description=read('README.rst'),

--- a/tests/test_aabb.py
+++ b/tests/test_aabb.py
@@ -123,4 +123,3 @@ def test_corners():
 
     for c in out_corners:
         assert c in aabb_corners
-

--- a/tests/test_aabbtree.py
+++ b/tests/test_aabbtree.py
@@ -115,6 +115,10 @@ def test_does_overlap():
     aabb6 = AABB([(0, 1), (5, 6)])
     aabb7 = AABB([(6.5, 6.5), (5.5, 5.5)])
 
+    not_tree = AABBTree()
+    not_tree.add(aabb6)
+    not_tree.add(aabb7)
+
     for aabb in (aabb5, aabb6, aabb7):
         for m in ('DFS', 'BFS'):
             assert not AABBTree().does_overlap(aabb, method=m)
@@ -122,13 +126,22 @@ def test_does_overlap():
     aabbs = standard_aabbs()
     for indices in itertools.permutations(range(4)):
         tree = AABBTree()
-        for i in indices:
+        alt_tree = AABBTree()
+        for i_ind, i in enumerate(indices):
             tree.add(aabbs[i])
+            alt_tree.add(aabbs[i_ind])
 
         for m in ('DFS', 'BFS'):
+            assert tree.does_overlap(tree, method=m)
+            assert alt_tree.does_overlap(tree, method=m)
+            assert tree.does_overlap(alt_tree, method=m)
+
             assert tree.does_overlap(aabb5, method=m)
             assert not tree.does_overlap(aabb6, method=m)
             assert not tree.does_overlap(aabb7, method=m)
+
+            assert not tree.does_overlap(not_tree, method=m)
+            assert not not_tree.does_overlap(tree, method=m)
 
 
 def test_overlap_aabbs():

--- a/tests/test_aabbtree.py
+++ b/tests/test_aabbtree.py
@@ -152,12 +152,18 @@ def test_overlap_aabbs():
     aabb6 = AABB([(0, 1), (5, 6)])
     aabb7 = AABB([(6.5, 6.5), (5.5, 5.5)])
 
+    not_tree = AABBTree()
+    not_tree.add(aabb6)
+    not_tree.add(aabb7)
+
     for indices in itertools.permutations(range(4)):
         tree = AABBTree()
         for i in indices:
             tree.add(aabbs[i], values[i])
 
         for m in ('DFS', 'BFS'):
+            assert all([box in tree.overlap_aabbs(tree, method=m)
+                        for box in aabbs])
             aabbs5 = tree.overlap_aabbs(aabb5, method=m)
             assert len(aabbs5) == 2
             for aabb in aabbs5:
@@ -165,6 +171,9 @@ def test_overlap_aabbs():
 
             assert tree.overlap_aabbs(aabb6) == []
             assert tree.overlap_aabbs(aabb7) == []
+
+            assert tree.overlap_aabbs(not_tree, method=m) == []
+            assert not_tree.overlap_aabbs(tree, method=m) == []
 
     for m in ('DFS', 'BFS'):
         assert AABBTree(aabb5).overlap_aabbs(aabb7, method=m) == []

--- a/tox.ini
+++ b/tox.ini
@@ -35,6 +35,7 @@ commands =
 
 
 [testenv:docs]
+basepython = python3.7
 deps =
        matplotlib
        sphinx


### PR DESCRIPTION
This PR address #7 by adding the ability to check for overlap between two trees. Before, the package could check for overlap between two bounding boxes and between one bounding box and one tree.