### PR TITLE
use shallow copy instead of deepcopy

### DIFF
--- a/.github/workflows/python_package.yaml
+++ b/.github/workflows/python_package.yaml
@@ -1,6 +1,11 @@
 name: CI
 
-on: [push]
+on:
+  push:
+    branches: [master, ]
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches: [master]
 
 jobs:
   pytest:

--- a/aabbtree.py
+++ b/aabbtree.py
@@ -1,6 +1,5 @@
 """Class definitions and methods for the AABB and AABBTree."""
 
-import copy
 from collections import deque
 
 __all__ = ['AABB', 'AABBTree']
@@ -404,7 +403,7 @@ class AABBTree(object):  # pylint: disable=useless-object-inheritance
             self.value = value
 
         elif self.is_leaf:
-            self.left = copy.deepcopy(self)
+            self.left = AABBTree(self.aabb, value=self.value, left=self.left, right=self.right)
             self.right = AABBTree(aabb, value)
 
             self.aabb = AABB.merge(self.aabb, aabb)
@@ -438,7 +437,7 @@ class AABBTree(object):  # pylint: disable=useless-object-inheritance
                 raise ValueError('Unrecognized method: ' + str(method))
 
             if branch_cost < left_cost and branch_cost < right_cost:
-                self.left = copy.deepcopy(self)
+                self.left = AABBTree(self.aabb, value=self.value, left=self.left, right=self.right)
                 self.right = AABBTree(aabb, value)
                 self.value = None
             elif left_cost < right_cost:

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ def read(fname):
 
 setup(
     name='aabbtree',
-    version='2.8.0',
+    version='2.8.1',
     license='MIT',
     description='Pure Python implementation of d-dimensional AABB tree.',
     long_description=read('README.rst'),

--- a/tests/test_aabbtree.py
+++ b/tests/test_aabbtree.py
@@ -257,6 +257,20 @@ def test_overlap_values_error():
         tree.overlap_values(aabbs[0], method=method)
 
 
+def test_return_the_origin_pass_in_value():
+    class Foo:
+        pass
+
+    tree = AABBTree()
+    value_set = {Foo() for _ in range(10)}
+
+    for value in value_set:
+        tree.add(AABB([(0, 1), (0, 1)]), value=value)
+
+    retrieved_value_set = set(tree.overlap_values(AABB([(0, 2), (0, 2)]), unique=False))
+    assert retrieved_value_set == value_set
+
+
 def test_depth():
     assert AABBTree().depth == 0
     assert standard_tree().depth == 2


### PR DESCRIPTION
Replace the deepcopy. It is safe to  simply move all the properties held by the old `AABBTree` to the new tree, because the properties in the old tree will immediately point to the new object reference, so no object will be referenced by two trees at the same time 